### PR TITLE
fix: disable gcr-ssh-agent autostart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gcr (3.41.1-3deepin1) unstable; urgency=medium
+
+  * disable gcr-ssh-agent autostart
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 12 Nov 2025 13:58:26 +0800
+
 gcr (3.41.1-3) unstable; urgency=medium
 
   * debian/watch: Only watch for 3.x versions

--- a/debian/patches/disable-gcr-ssh-agent-autostart.patch
+++ b/debian/patches/disable-gcr-ssh-agent-autostart.patch
@@ -1,0 +1,26 @@
+Description: Disable gcr-ssh-agent autostart
+ Disable automatic startup of gcr-ssh-agent service and socket
+ since the system is using gpg-agent for SSH authentication.
+Origin: vendor
+Forwarded: not-needed
+Last-Update: 2025-11-12
+Index: gcr/gcr/gcr-ssh-agent.service.in
+===================================================================
+--- gcr.orig/gcr/gcr-ssh-agent.service.in
++++ gcr/gcr/gcr-ssh-agent.service.in
+@@ -12,4 +12,4 @@ Restart=on-failure
+ 
+ [Install]
+ Also=gcr-ssh-agent.socket
+-WantedBy=graphical-session-pre.target
++# WantedBy=graphical-session-pre.target
+Index: gcr/gcr/gcr-ssh-agent.socket
+===================================================================
+--- gcr.orig/gcr/gcr-ssh-agent.socket
++++ gcr/gcr/gcr-ssh-agent.socket
+@@ -8,4 +8,4 @@ ListenStream=%t/gcr/ssh
+ DirectoryMode=0700
+ 
+ [Install]
+-WantedBy=sockets.target
++# WantedBy=sockets.target

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 systemd-Start-with-graphical-session-instead-of-default.patch
 Fix-FTBFS-on-x32.patch
+disable-gcr-ssh-agent-autostart.patch

--- a/debian/rules
+++ b/debian/rules
@@ -30,3 +30,6 @@ override_dh_auto_test:
 
 override_dh_makeshlibs:
 	dh_makeshlibs -- -c4
+
+override_dh_installsystemduser:
+	dh_installsystemduser --no-enable


### PR DESCRIPTION
Disable automatic startup of gcr-ssh-agent service and socket by commenting out the WantedBy directives in both service and socket files. This change is necessary because the system is using gpg-agent for SSH authentication instead of gcr-ssh-agent, preventing conflicts between the two agents. The patch file is added to the Debian patches series and the dh_installsystemduser override is modified to prevent automatic service enablement during package installation.

Log: Disabled gcr-ssh-agent automatic startup to avoid conflicts with gpg-agent

Influence:
1. Verify gcr-ssh-agent service does not start automatically after system boot
2. Check that gpg-agent SSH functionality remains unaffected
3. Test manual startup of gcr-ssh-agent if needed
4. Verify no socket activation conflicts occur
5. Confirm systemd user services list shows gcr-ssh-agent as disabled

fix: 禁用 gcr-ssh-agent 自动启动

通过注释服务文件和套接字文件中的 WantedBy 指令来禁用 gcr-ssh-agent 服务
和套接字的自动启动。此变更是必要的，因为系统使用 gpg-agent 进行 SSH 认
证而非 gcr-ssh-agent，可避免两个代理之间的冲突。补丁文件已添加到 Debian
补丁系列中，并修改了 dh_installsystemduser 覆盖以防止包安装期间自动启用
服务。

Log: 禁用 gcr-ssh-agent 自动启动以避免与 gpg-agent 冲突

Influence:
1. 验证系统启动后 gcr-ssh-agent 服务不会自动启动
2. 检查 gpg-agent SSH 功能是否保持正常
3. 测试需要时手动启动 gcr-ssh-agent
4. 验证不会发生套接字激活冲突
5. 确认 systemd 用户服务列表显示 gcr-ssh-agent 为禁用状态 PMS: BUG-339543